### PR TITLE
Fix fuzzing code

### DIFF
--- a/fuzz/fuzz_targets/jrsonnet-fuzz.rs
+++ b/fuzz/fuzz_targets/jrsonnet-fuzz.rs
@@ -1,16 +1,13 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use std::str;
-use jrsonnet_parser::*;
-use std::borrow::Cow;
 
-fuzz_target!(|data: &[u8]| {
-    match str::from_utf8(&data[0..]) {
-        Ok(in_string)=>{
-            parse(in_string, &ParserSettings {
-                file_name: Source::new_virtual(Cow::Borrowed("<test>")),
-            });
-        },
-        Err(..)=>()
-    }
+use jrsonnet_parser::*;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|code: String| {
+	let _ = parse(
+		&code.to_string(),
+		&ParserSettings {
+			file_name: Source::new_virtual(IStr::from("<test>"), IStr::from(code)),
+		},
+	);
 });


### PR DESCRIPTION
Looks like `Source` now needs to interned strings instead of `Cow`s. The runs can be seen [here](https://mayhem.forallsecure.com/ysthakur/jrsonnet).